### PR TITLE
Fixed docker-compose.yml

### DIFF
--- a/infra_bt/docker-compose.yml
+++ b/infra_bt/docker-compose.yml
@@ -29,7 +29,10 @@ services:
       retries: 5
 
   backend:
-    build: ../backend/
+    build:
+      context: ../backend/
+      args:
+          - PYTHON_VERSION_BUILD=${PYTHON_VERSION_BUILD}
     env_file: .env
     volumes:
       - static_data:/backend_static


### PR DESCRIPTION
Исправил ошибку с передачей переменной в докер контейнер для сборки при поднятии локальных докер контейнеров(необходимо в infra_bt/.env доюавлять переменную PYTHON_VERSION_BUILD=python:3.10.6-alpine3.16 с тэгом докер образа для сборки бэкэнда).