### PR TITLE
Add « and » in title available symbols

### DIFF
--- a/backend/projects/validators.py
+++ b/backend/projects/validators.py
@@ -104,7 +104,7 @@ def validate_title(value):
     Валидирует длину и символы в Названии организации.
     """
     regex_validator = RegexValidator(
-        regex=r'^[а-яА-ЯёЁ\d\s\-\.\,\&\+\№\!]+$',
+        regex=r'^[а-яА-ЯёЁ\d\s\-\.\,\&\+\№\!\«\»]+$',
         message=settings.MESSAGE_TITLE_CYRILLIC,
     )
     min_length_validator = MinLengthValidator(


### PR DESCRIPTION
По просьбе фронтов добавил прием кавычек («») в названии организации, об этом есть упоминание в Требованиях.